### PR TITLE
Fixed missing archive icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. Dates are d
 
 From here on is the changelog of the original repository:
 
+#### [v1.0.4]()
+
+> January 31, 2025
+
+- Fix missing archive icons.
+
 #### [v1.0.3]()
 
 > January 19, 2025

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "a-wl-file-icon-vscode",
   "displayName": "Atom Material Icons + WL",
   "description": "Atom Material Icons for Visual Studio Code with wider WL support",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/ToneAr/a-file-icon-vscode.git"

--- a/src/icons/files/archive.ts
+++ b/src/icons/files/archive.ts
@@ -1,42 +1,14 @@
 export const archive = [
   {
-    fileExtensions: [
-      '7z',
-      '7zip',
-      'bz2',
-      'ear',
-      'egg',
-      'gz',
-      'gzip',
-    ],
+    fileExtensions: ['7z', '7zip', 'bz2', 'ear', 'egg', 'gz', 'gzip'],
     name: 'archive',
   },
   {
-    fileExtensions: [
-      'hak',
-      'hqx',
-      'lz',
-      'lzma',
-      'lzo',
-      'pzip',
-      'rar',
-      'saz',
-      'sit',
-    ],
-    name: 'archive2',
+    fileExtensions: ['hak', 'hqx', 'lz', 'lzma', 'lzo', 'pzip', 'rar', 'saz', 'sit'],
+    name: 'archive',
   },
   {
-    fileExtensions: [
-      'tar',
-      'tgz',
-      'tlz',
-      'whl',
-      'xar',
-      'xz',
-      'z',
-      'zip',
-      'zipx',
-    ],
-    name: 'archive3',
+    fileExtensions: ['tar', 'tgz', 'tlz', 'whl', 'xar', 'xz', 'z', 'zip', 'zipx'],
+    name: 'archive',
   },
 ];


### PR DESCRIPTION
The new version 1.0.4 includes a fix for the missing archive icons issue. The icon definitions have been simplified and corrected in the code, ensuring all expected file extensions are properly associated with their respective archive icons. This update is reflected in both the package.json file and the changelog.
