### PR TITLE
WL package files support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file. Dates are d
 
 From here on is the changelog of the original repository:
 
+#### [v1.0.6]()
+
+> June 21, 2025
+
+- Change icons of package files to white wolfie icon
+  - Public(.wl|m)
+  - Private(.wl|m)
+  - PackageScope(.wl|m)
+  - PublicScope(.wl|m)
+  - *.init(.wl|m)
+
 #### [v1.0.5]()
 
 > January 31, 2025

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,192 +1,189 @@
-import typescriptEslint from "@typescript-eslint/eslint-plugin";
-import _import from "eslint-plugin-import";
-import unicorn from "eslint-plugin-unicorn";
-import i18Next from "eslint-plugin-i18next";
-import sortKeysFix from "eslint-plugin-sort-keys-fix";
-import {fixupPluginRules} from "@eslint/compat";
-import globals from "globals";
-import tsParser from "@typescript-eslint/parser";
-import jsonc from "eslint-plugin-jsonc";
-import parser from "jsonc-eslint-parser";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
-import js from "@eslint/js";
-import {FlatCompat} from "@eslint/eslintrc";
+import typescriptEslint from '@typescript-eslint/eslint-plugin';
+import _import from 'eslint-plugin-import';
+import unicorn from 'eslint-plugin-unicorn';
+import i18Next from 'eslint-plugin-i18next';
+import sortKeysFix from 'eslint-plugin-sort-keys-fix';
+import { fixupPluginRules } from '@eslint/compat';
+import globals from 'globals';
+import tsParser from '@typescript-eslint/parser';
+import jsonc from 'eslint-plugin-jsonc';
+import parser from 'jsonc-eslint-parser';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import js from '@eslint/js';
+import { FlatCompat } from '@eslint/eslintrc';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
   baseDirectory: __dirname,
   recommendedConfig: js.configs.recommended,
-  allConfig: js.configs.all
+  allConfig: js.configs.all,
 });
 
-export default [...compat.extends(
-  "plugin:@typescript-eslint/recommended",
-  "plugin:unicorn/recommended",
-  "plugin:i18next/recommended",
-), {
-  plugins: {
-    "@typescript-eslint": typescriptEslint,
-    import: fixupPluginRules(_import),
-    unicorn,
-    i18next: i18Next,
-    "sort-keys-fix": sortKeysFix,
-  },
-
-  languageOptions: {
-    globals: {
-      ...globals.browser,
-      ...globals.node,
+export default [
+  ...compat.extends(
+    'plugin:@typescript-eslint/recommended',
+    'plugin:unicorn/recommended',
+    'plugin:i18next/recommended'
+  ),
+  {
+    plugins: {
+      '@typescript-eslint': typescriptEslint,
+      import: fixupPluginRules(_import),
+      unicorn,
+      i18next: i18Next,
+      'sort-keys-fix': sortKeysFix,
     },
 
-    parser: tsParser,
-    ecmaVersion: 5,
-    sourceType: "module",
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
 
-    parserOptions: {
-      project: "tsconfig.json",
+      parser: tsParser,
+      ecmaVersion: 5,
+      sourceType: 'module',
+
+      parserOptions: {
+        project: 'tsconfig.json',
+      },
     },
   },
-}, ...compat.extends("plugin:@typescript-eslint/recommended").map(config => ({
-  ...config,
-  files: ["**/**.ts"],
-})), {
-  files: ["**/**.ts"],
+  ...compat.extends('plugin:@typescript-eslint/recommended').map((config) => ({
+    ...config,
+    files: ['**/**.ts'],
+  })),
+  {
+    files: ['**/**.ts'],
 
-  rules: {
-    "@typescript-eslint/array-type": ["error", {
-      default: "array-simple",
-    }],
-
-    "@typescript-eslint/consistent-indexed-object-style": "error",
-    "@typescript-eslint/consistent-type-definitions": ["error", "type"],
-    "@typescript-eslint/consistent-type-exports": "error",
-    "@typescript-eslint/consistent-type-imports": "error",
-
-    "@typescript-eslint/member-ordering": ["error", {
-      default: [
-        "signature",
-        "field",
-        "static-initialization",
-        "constructor",
-        ["get", "set"],
-        "method",
-      ],
-    }],
-
-    "@typescript-eslint/method-signature-style": "error",
-
-    "@typescript-eslint/naming-convention": ["warn", {
-      format: ["camelCase", "UPPER_CASE", "PascalCase"],
-      selector: "variable",
-    }],
-
-    "@typescript-eslint/no-confusing-non-null-assertion": "error",
-    "@typescript-eslint/no-confusing-void-expression": "off",
-    "@typescript-eslint/no-dupe-class-members": "error",
-    "@typescript-eslint/no-duplicate-enum-values": "error",
-    "@typescript-eslint/no-empty-interface": "error",
-    "@typescript-eslint/no-explicit-any": "warn",
-    "@typescript-eslint/no-extra-non-null-assertion": "error",
-    "@typescript-eslint/no-extra-parens": "off",
-    "@typescript-eslint/no-extraneous-class": "warn",
-    "@typescript-eslint/no-inferrable-types": "error",
-    "@typescript-eslint/prefer-namespace-keyword": "error",
-    "@typescript-eslint/sort-type-constituents": "error",
-    camelcase: "error",
-    eqeqeq: ["error", "smart"],
-
-    "id-blacklist": [
-      "error",
-      "any",
-      "Number",
-      "number",
-      "String",
-      "string",
-      "Boolean",
-      "boolean",
-      "Undefined",
-    ],
-
-    "id-match": "error",
-    "import/exports-last": "error",
-    "import/first": "error",
-    "import/named": "error",
-    "import/newline-after-import": "error",
-    "import/no-cycle": "error",
-    "import/no-default-export": "error",
-    "import/no-duplicates": "error",
-    "import/no-internal-modules": "off",
-    "import/no-namespace": "error",
-    "import/order": ["error", {
-      groups: [
-        ["builtin", "external"],
-        "internal",
-        ["parent", "sibling", "index"],
-        ["type"],
+    rules: {
+      '@typescript-eslint/array-type': [
+        'error',
+        {
+          default: 'array-simple',
+        },
       ],
 
-      "newlines-between": "always",
-    }],
+      '@typescript-eslint/consistent-indexed-object-style': 'error',
+      '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
+      '@typescript-eslint/consistent-type-exports': 'error',
+      '@typescript-eslint/consistent-type-imports': 'error',
 
-    "no-eval": "error",
-    "no-trailing-spaces": "error",
-    "no-underscore-dangle": "off",
-    "no-unsafe-finally": "error",
-    "no-var": "error",
-    "prefer-const": "error",
-    "sort-keys": "error",
-    "sort-keys-fix/sort-keys-fix": "error",
-    "spaced-comment": "error",
+      '@typescript-eslint/member-ordering': [
+        'error',
+        {
+          default: ['signature', 'field', 'static-initialization', 'constructor', ['get', 'set'], 'method'],
+        },
+      ],
 
-    "unicorn/filename-case": ["error", {
-      cases: {
-        camelCase: true,
-        pascalCase: true,
-      },
-    }],
+      '@typescript-eslint/method-signature-style': 'error',
 
-    "unicorn/no-array-reduce": "off",
-    "unicorn/no-null": "off",
-    "unicorn/prefer-code-point": "off",
-    "unicorn/prefer-module": "off",
-    "unicorn/prefer-ternary": ["off", "only-single-line"],
-    "unicorn/import-style": "off",
+      '@typescript-eslint/naming-convention': [
+        'warn',
+        {
+          format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
+          selector: 'variable',
+        },
+      ],
 
-    "unicorn/prevent-abbreviations": ["error", {
-      replacements: {
-        env: false,
-        i: false,
-        j: false,
-      },
-    }],
+      '@typescript-eslint/no-confusing-non-null-assertion': 'error',
+      '@typescript-eslint/no-confusing-void-expression': 'off',
+      '@typescript-eslint/no-dupe-class-members': 'error',
+      '@typescript-eslint/no-duplicate-enum-values': 'error',
+      '@typescript-eslint/no-empty-interface': 'error',
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-extra-non-null-assertion': 'error',
+      '@typescript-eslint/no-extra-parens': 'off',
+      '@typescript-eslint/no-extraneous-class': 'warn',
+      '@typescript-eslint/no-inferrable-types': 'error',
+      '@typescript-eslint/prefer-namespace-keyword': 'error',
+      '@typescript-eslint/sort-type-constituents': 'error',
+      camelcase: 'error',
+      eqeqeq: ['error', 'smart'],
+
+      'id-blacklist': ['error', 'any', 'Number', 'number', 'String', 'string', 'Boolean', 'boolean', 'Undefined'],
+
+      'id-match': 'error',
+      'import/exports-last': 'error',
+      'import/first': 'error',
+      'import/named': 'error',
+      'import/newline-after-import': 'error',
+      'import/no-cycle': 'error',
+      'import/no-default-export': 'error',
+      'import/no-duplicates': 'error',
+      'import/no-internal-modules': 'off',
+      'import/no-namespace': 'error',
+      'import/order': [
+        'error',
+        {
+          groups: [['builtin', 'external'], 'internal', ['parent', 'sibling', 'index'], ['type']],
+
+          'newlines-between': 'always',
+        },
+      ],
+
+      'no-eval': 'error',
+      'no-trailing-spaces': 'error',
+      'no-underscore-dangle': 'off',
+      'no-unsafe-finally': 'error',
+      'no-var': 'error',
+      'prefer-const': 'error',
+      'sort-keys': 'error',
+      'sort-keys-fix/sort-keys-fix': 'error',
+      'spaced-comment': 'error',
+
+      'unicorn/filename-case': [
+        'error',
+        {
+          cases: {
+            camelCase: true,
+            pascalCase: true,
+          },
+        },
+      ],
+
+      'unicorn/no-array-reduce': 'off',
+      'unicorn/no-null': 'off',
+      'unicorn/prefer-code-point': 'off',
+      'unicorn/prefer-module': 'off',
+      'unicorn/prefer-ternary': ['off', 'only-single-line'],
+      'unicorn/import-style': 'off',
+
+      'unicorn/prevent-abbreviations': [
+        'error',
+        {
+          replacements: {
+            env: false,
+            i: false,
+            j: false,
+          },
+        },
+      ],
+    },
   },
-}, ...compat.extends("plugin:jsonc/recommended-with-json").map(config => ({
-  ...config,
-  files: ["**/*.json"],
-})), {
-  files: ["**/*.json"],
+  ...compat.extends('plugin:jsonc/recommended-with-json').map((config) => ({
+    ...config,
+    files: ['**/*.json'],
+  })),
+  {
+    files: ['**/*.json'],
 
-  plugins: {
-    jsonc,
+    plugins: {
+      jsonc,
+    },
+
+    languageOptions: {
+      parser: parser,
+    },
+
+    ignores: ['build/**', '**/*.d.ts', 'package.json', 'launch.json', 'tsconfig.json'],
+
+    rules: {
+      'jsonc/key-name-casing': 'off',
+      'jsonc/no-comments': 'off',
+      //   'jsonc/sort-keys': 'error',
+    },
   },
-
-  languageOptions: {
-    parser: parser,
-  },
-
-  ignores: [
-    "build/**",
-    "**/*.d.ts",
-    "package.json",
-    "launch.json",
-    "tsconfig.json"
-  ],
-
-  rules: {
-    "jsonc/key-name-casing": "off",
-    "jsonc/no-comments": "off",
-    "jsonc/sort-keys": "error",
-  },
-}];
+];

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "a-wl-file-icon-vscode",
   "displayName": "Atom Material Icons + WL",
   "description": "Atom Material Icons for Visual Studio Code with wider WL support",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/ToneAr/a-file-icon-vscode.git"

--- a/src/icons/files/w.ts
+++ b/src/icons/files/w.ts
@@ -141,7 +141,19 @@ export const wFiles = [
     name: 'wolfram_paclet',
   },
   {
-    fileNames: ['init.m'],
+    fileExtensions: ['init.m', 'init.wl'],
+    fileNames: [
+      'init.m',
+      'init.wl',
+      'Private.wl',
+      'Private.m',
+      'Public.wl',
+      'Public.m',
+      'PackageScope.wl',
+      'PackageScope.m',
+      'PublicScope.wl',
+      'PublicScope.m',
+    ],
     name: 'wolfram_init',
   },
   {


### PR DESCRIPTION
Updates the package version to 1.0.6.
Changes the icons for WL package files to the white wolfie icon to improve consistency and visual clarity.
This affects files with the following extensions: .wl, .m, .init(.wl|.m), Private(.wl|.m), Public(.wl|.m), PackageScope(.wl|.m), and PublicScope(.wl|.m).
Also, updates the icon generator submodule.
